### PR TITLE
Create Hilbert Space.v

### DIFF
--- a/Hilbert Space.v
+++ b/Hilbert Space.v
@@ -1,0 +1,103 @@
+Require Import Reals.
+Require Import Complex.
+Require Import Lra.
+Require Import ClassicalEpsilon.
+Require Import FunctionalExtensionality.
+
+(* First, we'll define what it means to be an inner product space *)
+Record InnerProductSpace := {
+  carrier : Type;
+  zero : carrier;
+  plus : carrier -> carrier -> carrier;
+  scalar_mult : C -> carrier -> carrier;
+  inner_product : carrier -> carrier -> C;
+  
+  (* Basic vector space axioms *)
+  plus_comm : forall x y, plus x y = plus y x;
+  plus_assoc : forall x y z, plus x (plus y z) = plus (plus x y) z;
+  plus_zero : forall x, plus x zero = x;
+  plus_inv : forall x, exists y, plus x y = zero;
+  
+  (* Scalar multiplication axioms *)
+  scalar_mult_1 : forall x, scalar_mult 1 x = x;
+  scalar_mult_dist : forall a x y,
+    scalar_mult a (plus x y) = plus (scalar_mult a x) (scalar_mult a y);
+  scalar_mult_comp : forall a b x,
+    scalar_mult a (scalar_mult b x) = scalar_mult (a * b) x;
+  
+  (* Inner product axioms *)
+  inner_product_conjugate_sym : forall x y,
+    inner_product x y = Cconj (inner_product y x);
+  inner_product_linear : forall x y z a,
+    inner_product (plus (scalar_mult a x) y) z =
+    Cplus (Cmult a (inner_product x z)) (inner_product y z);
+  inner_product_pos : forall x,
+    Cre (inner_product x x) >= 0;
+  inner_product_sep : forall x,
+    Cre (inner_product x x) = 0 -> x = zero
+}.
+
+(* Define norm in terms of inner product *)
+Definition norm {V : InnerProductSpace} (x : carrier V) : R :=
+  sqrt (Cre (inner_product V x x)).
+
+(* Cauchy sequences in our space *)
+Definition is_Cauchy {V : InnerProductSpace} (seq : nat -> carrier V) : Prop :=
+  forall eps : R,
+  eps > 0 ->
+  exists N : nat,
+  forall n m : nat,
+  n >= N -> m >= N ->
+  norm (plus V (seq n) (scalar_mult V (-1) (seq m))) < eps.
+
+(* Definition of completeness *)
+Definition is_complete (V : InnerProductSpace) : Prop :=
+  forall seq : nat -> carrier V,
+  is_Cauchy seq ->
+  exists limit : carrier V,
+  forall eps : R,
+  eps > 0 ->
+  exists N : nat,
+  forall n : nat,
+  n >= N ->
+  norm (plus V (seq n) (scalar_mult V (-1) limit)) < eps.
+
+(* Finally, we can define a Hilbert space *)
+Record HilbertSpace := {
+  underlying_space :> InnerProductSpace;
+  completeness : is_complete underlying_space
+}.
+
+(* Some useful theorems about Hilbert spaces *)
+
+(* Pythagorean theorem *)
+Theorem pythagorean {H : HilbertSpace} :
+  forall x y : carrier H,
+  inner_product H x y = 0 ->
+  norm (plus H x y) ^ 2 = norm x ^ 2 + norm y ^ 2.
+Proof.
+  (* Proof would go here *)
+Admitted.
+
+(* Parallelogram law *)
+Theorem parallelogram_law {H : HilbertSpace} :
+  forall x y : carrier H,
+  norm (plus H x y) ^ 2 + norm (plus H x (scalar_mult H (-1) y)) ^ 2 =
+  2 * (norm x ^ 2 + norm y ^ 2).
+Proof.
+  (* Proof would go here *)
+Admitted.
+
+(* Best approximation theorem *)
+Theorem best_approximation {H : HilbertSpace} (K : carrier H -> Prop) :
+  (* Assuming K is closed and convex *)
+  forall x : carrier H,
+  exists! y : carrier H,
+  K y /\
+  forall z : carrier H,
+  K z ->
+  norm (plus H x (scalar_mult H (-1) y)) <= 
+  norm (plus H x (scalar_mult H (-1) z)).
+Proof.
+  (* Proof would go here *)
+Admitted.


### PR DESCRIPTION
```coq
Require Import Reals.
Require Import Complex.
Require Import Lra.
Require Import ClassicalEpsilon.
Require Import FunctionalExtensionality.

(* First, we'll define what it means to be an inner product space *)
Record InnerProductSpace := {
  carrier : Type;
  zero : carrier;
  plus : carrier -> carrier -> carrier;
  scalar_mult : C -> carrier -> carrier;
  inner_product : carrier -> carrier -> C;
  
  (* Basic vector space axioms *)
  plus_comm : forall x y, plus x y = plus y x;
  plus_assoc : forall x y z, plus x (plus y z) = plus (plus x y) z;
  plus_zero : forall x, plus x zero = x;
  plus_inv : forall x, exists y, plus x y = zero;
  
  (* Scalar multiplication axioms *)
  scalar_mult_1 : forall x, scalar_mult 1 x = x;
  scalar_mult_dist : forall a x y,
    scalar_mult a (plus x y) = plus (scalar_mult a x) (scalar_mult a y);
  scalar_mult_comp : forall a b x,
    scalar_mult a (scalar_mult b x) = scalar_mult (a * b) x;
  
  (* Inner product axioms *)
  inner_product_conjugate_sym : forall x y,
    inner_product x y = Cconj (inner_product y x);
  inner_product_linear : forall x y z a,
    inner_product (plus (scalar_mult a x) y) z =
    Cplus (Cmult a (inner_product x z)) (inner_product y z);
  inner_product_pos : forall x,
    Cre (inner_product x x) >= 0;
  inner_product_sep : forall x,
    Cre (inner_product x x) = 0 -> x = zero
}.

(* Define norm in terms of inner product *)
Definition norm {V : InnerProductSpace} (x : carrier V) : R :=
  sqrt (Cre (inner_product V x x)).

(* Cauchy sequences in our space *)
Definition is_Cauchy {V : InnerProductSpace} (seq : nat -> carrier V) : Prop :=
  forall eps : R,
  eps > 0 ->
  exists N : nat,
  forall n m : nat,
  n >= N -> m >= N ->
  norm (plus V (seq n) (scalar_mult V (-1) (seq m))) < eps.

(* Definition of completeness *)
Definition is_complete (V : InnerProductSpace) : Prop :=
  forall seq : nat -> carrier V,
  is_Cauchy seq ->
  exists limit : carrier V,
  forall eps : R,
  eps > 0 ->
  exists N : nat,
  forall n : nat,
  n >= N ->
  norm (plus V (seq n) (scalar_mult V (-1) limit)) < eps.

(* Finally, we can define a Hilbert space *)
Record HilbertSpace := {
  underlying_space :> InnerProductSpace;
  completeness : is_complete underlying_space
}.

(* Some useful theorems about Hilbert spaces *)

(* Pythagorean theorem *)
Theorem pythagorean {H : HilbertSpace} :
  forall x y : carrier H,
  inner_product H x y = 0 ->
  norm (plus H x y) ^ 2 = norm x ^ 2 + norm y ^ 2.
Proof.
  (* Proof would go here *)
Admitted.

(* Parallelogram law *)
Theorem parallelogram_law {H : HilbertSpace} :
  forall x y : carrier H,
  norm (plus H x y) ^ 2 + norm (plus H x (scalar_mult H (-1) y)) ^ 2 =
  2 * (norm x ^ 2 + norm y ^ 2).
Proof.
  (* Proof would go here *)
Admitted.

(* Best approximation theorem *)
Theorem best_approximation {H : HilbertSpace} (K : carrier H -> Prop) :
  (* Assuming K is closed and convex *)
  forall x : carrier H,
  exists! y : carrier H,
  K y /\
  forall z : carrier H,
  K z ->
  norm (plus H x (scalar_mult H (-1) y)) <= 
  norm (plus H x (scalar_mult H (-1) z)).
Proof.
  (* Proof would go here *)
Admitted.
```