### PR TITLE
Create Mind bending fact about Fermonic  integral and residual theore…

### DIFF
--- a/OpenAI/Mind bending fact about Fermonic  integral and residual theorerom vs integral in real analysis.md
+++ b/OpenAI/Mind bending fact about Fermonic  integral and residual theorerom vs integral in real analysis.md
@@ -1,0 +1,125 @@
+# Mind bending fact about Fermonic  integral and residual theorerom vs integral in real analysis 
+
+Here's a mind-bending fact about **fermionic integrals** (Grassmann integrals) and **residue theorem vs. real analysis integrals**:
+
+### **Fermionic Integrals Are More Like Differentiation Than Integration**
+In **real analysis**, integration is typically the inverse of differentiation. However, in **fermionic integrals** (integrals over Grassmann numbers, used in quantum field theory), integration behaves like differentiation rather than summation. That is, for a Grassmann variable \( \theta \):
+
+\[
+\int d\theta \, \theta = 1, \quad \int d\theta \, 1 = 0
+\]
+
+This is in stark contrast to real analysis, where integration accumulates area rather than annihilating constants.
+
+---
+
+### **Residue Theorem vs. Real Integrals: Residues See "Infinity" in a Finite Contour**
+In real analysis, improper integrals often diverge at singularities, requiring special techniques like the **Cauchy Principal Value** to handle them. However, in **complex analysis**, the **residue theorem** allows you to evaluate certain real integrals **by summing finite residues of singularities enclosed in a contour**.
+
+A classic mind-bending example is:
+
+\[
+\int_{-\infty}^{\infty} \frac{dx}{x^2 + 1} = \pi
+\]
+
+Instead of struggling with limits and convergence in real analysis, you can solve this in complex analysis by:
+1. Closing the contour in the **upper half-plane** (using a semicircle).
+2. Identifying the **pole at \( z = i \)**.
+3. Using the **residue theorem**, which instantly gives:
+
+   \[
+   \oint \frac{dz}{z^2 + 1} = 2\pi i \times \text{Res}_{z=i} \left( \frac{1}{z^2+1} \right) = \pi
+   \]
+
+This is striking because a **finite sum of residues captures the whole integral** without explicitly computing limits or worrying about divergent behavior.
+
+---
+
+### **Conclusion**
+1. **Fermionic integrals act like differentiation**, breaking the fundamental link between integration and summation in real analysis.
+2. **Residue theorem "hides" infinite contributions**, converting divergent real integrals into **finite algebraic sums** using singularities.
+
+These two results illustrate how different branches of mathematics redefine fundamental operations, making us rethink integration itself!
+
+## Nth coefficient of power series 
+
+The **nth coefficient** of a power series expansion is a fundamental concept in mathematical analysis and complex function theory. Let's break it down systematically.
+
+### **General Form of a Power Series**
+A power series centered at \( x = 0 \) is written as:
+
+\[
+f(x) = \sum_{n=0}^{\infty} a_n x^n
+\]
+
+where:
+- \( a_n \) are the **coefficients** of the series,
+- \( x^n \) are the monomials,
+- The series converges for values of \( x \) within its **radius of convergence**.
+
+### **Finding the nth Coefficient**
+The \( n \)th coefficient \( a_n \) of the power series of \( f(x) \) can be found using the **Taylor series expansion formula**:
+
+\[
+a_n = \frac{f^{(n)}(0)}{n!}
+\]
+
+where \( f^{(n)}(0) \) is the \( n \)th derivative of \( f(x) \) evaluated at \( x = 0 \).
+
+### **Example 1: Power Series of \( e^x \)**
+The function \( e^x \) has derivatives:
+
+\[
+f^{(n)}(x) = e^x
+\]
+
+Evaluating at \( x = 0 \):
+
+\[
+f^{(n)}(0) = e^0 = 1
+\]
+
+Thus, the coefficients of the power series for \( e^x \) are:
+
+\[
+a_n = \frac{1}{n!}
+\]
+
+leading to the well-known expansion:
+
+\[
+e^x = \sum_{n=0}^{\infty} \frac{x^n}{n!}
+\]
+
+### **Example 2: Power Series of \( \frac{1}{1-x} \)**
+For the geometric series:
+
+\[
+\frac{1}{1-x} = \sum_{n=0}^{\infty} x^n, \quad |x| < 1
+\]
+
+Comparing terms, we see:
+
+\[
+a_n = 1
+\]
+
+for all \( n \), meaning each term has coefficient **1**.
+
+### **Using Contour Integration (Residue Theorem)**
+For a more advanced method, we can compute \( a_n \) using **Cauchy’s coefficient formula**:
+
+\[
+a_n = \frac{1}{2\pi i} \oint \frac{f(z)}{z^{n+1}} dz
+\]
+
+where the integral is taken around a closed contour enclosing \( z = 0 \). This method is particularly useful in **asymptotic analysis and generating functions**.
+
+---
+
+### **Conclusion**
+- The **nth coefficient** of a power series can be found using \( a_n = \frac{f^{(n)}(0)}{n!} \).
+- For simple functions like \( e^x \) and \( \frac{1}{1-x} \), we directly obtain coefficients from known series.
+- For more complex cases, **residue calculus** can extract coefficients efficiently.
+
+Would you like a computation for a specific function?


### PR DESCRIPTION
…rom vs integral in real analysis.md

# Mind bending fact about Fermonic  integral and residual theorerom vs integral in real analysis 

Here's a mind-bending fact about **fermionic integrals** (Grassmann integrals) and **residue theorem vs. real analysis integrals**:

### **Fermionic Integrals Are More Like Differentiation Than Integration** In **real analysis**, integration is typically the inverse of differentiation. However, in **fermionic integrals** (integrals over Grassmann numbers, used in quantum field theory), integration behaves like differentiation rather than summation. That is, for a Grassmann variable \( \theta \):

\[
\int d\theta \, \theta = 1, \quad \int d\theta \, 1 = 0 \]

This is in stark contrast to real analysis, where integration accumulates area rather than annihilating constants.

---

### **Residue Theorem vs. Real Integrals: Residues See "Infinity" in a Finite Contour** In real analysis, improper integrals often diverge at singularities, requiring special techniques like the **Cauchy Principal Value** to handle them. However, in **complex analysis**, the **residue theorem** allows you to evaluate certain real integrals **by summing finite residues of singularities enclosed in a contour**.

A classic mind-bending example is:

\[
\int_{-\infty}^{\infty} \frac{dx}{x^2 + 1} = \pi
\]

Instead of struggling with limits and convergence in real analysis, you can solve this in complex analysis by:
1. Closing the contour in the **upper half-plane** (using a semicircle).
2. Identifying the **pole at \( z = i \)**.
3. Using the **residue theorem**, which instantly gives:

   \[ \oint \frac{dz}{z^2 + 1} = 2\pi i \times \text{Res}_{z=i} \left( \frac{1}{z^2+1} \right) = \pi \]

This is striking because a **finite sum of residues captures the whole integral** without explicitly computing limits or worrying about divergent behavior.

---

### **Conclusion**
1. **Fermionic integrals act like differentiation**, breaking the fundamental link between integration and summation in real analysis.
2. **Residue theorem "hides" infinite contributions**, converting divergent real integrals into **finite algebraic sums** using singularities.

These two results illustrate how different branches of mathematics redefine fundamental operations, making us rethink integration itself!

## Nth coefficient of power series 

The **nth coefficient** of a power series expansion is a fundamental concept in mathematical analysis and complex function theory. Let's break it down systematically.

### **General Form of a Power Series**
A power series centered at \( x = 0 \) is written as:

\[
f(x) = \sum_{n=0}^{\infty} a_n x^n
\]

where:
- \( a_n \) are the **coefficients** of the series,
- \( x^n \) are the monomials,
- The series converges for values of \( x \) within its **radius of convergence**.

### **Finding the nth Coefficient**
The \( n \)th coefficient \( a_n \) of the power series of \( f(x) \) can be found using the **Taylor series expansion formula**:

\[
a_n = \frac{f^{(n)}(0)}{n!}
\]

where \( f^{(n)}(0) \) is the \( n \)th derivative of \( f(x) \) evaluated at \( x = 0 \).

### **Example 1: Power Series of \( e^x \)**
The function \( e^x \) has derivatives:

\[
f^{(n)}(x) = e^x
\]

Evaluating at \( x = 0 \):

\[
f^{(n)}(0) = e^0 = 1
\]

Thus, the coefficients of the power series for \( e^x \) are:

\[
a_n = \frac{1}{n!}
\]

leading to the well-known expansion:

\[
e^x = \sum_{n=0}^{\infty} \frac{x^n}{n!}
\]

### **Example 2: Power Series of \( \frac{1}{1-x} \)** For the geometric series:

\[
\frac{1}{1-x} = \sum_{n=0}^{\infty} x^n, \quad |x| < 1 \]

Comparing terms, we see:

\[
a_n = 1
\]

for all \( n \), meaning each term has coefficient **1**.

### **Using Contour Integration (Residue Theorem)** For a more advanced method, we can compute \( a_n \) using **Cauchy’s coefficient formula**:

\[
a_n = \frac{1}{2\pi i} \oint \frac{f(z)}{z^{n+1}} dz \]

where the integral is taken around a closed contour enclosing \( z = 0 \). This method is particularly useful in **asymptotic analysis and generating functions**.

---

### **Conclusion**
- The **nth coefficient** of a power series can be found using \( a_n = \frac{f^{(n)}(0)}{n!} \).
- For simple functions like \( e^x \) and \( \frac{1}{1-x} \), we directly obtain coefficients from known series.
- For more complex cases, **residue calculus** can extract coefficients efficiently.

Would you like a computation for a specific function?